### PR TITLE
fix README and build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,29 @@ SOFTWARE.
 
 # Build Instructions
 
-1. Create an empty folder named "4ed" to contain the codebase.
-2. Clone the repository
-3. Rename the folder containing the repository to "code"
-4. At the same level as the "4ed" folder, clone the "4coder-non-source" repository
-5. 
+## Download required repositories
+
+1. Create an empty folder for the source.
+2. Clone this repository there to a folder named "code".
+   - `git clone -o code <url>`
+3. At the same level as the "code" folder, clone the "4coder-non-source" repository.
+
+Result should be like this:
+
+```
+root_dir
+  - code   <this repo>
+  - 4coder-non-source
+```
+
+## Compile
+
+1. Setup compiler.
    - On windows setup the visual studio command line magic sauce so that "cl" works
    - On linux setup g++
    - On mac setup clang
-6. Navigate to the "4ed/code" folder.
-7. 
+6. Navigate to the "code" folder.
+7. Run build script.
    - On windows run `bin\build.bat`
    - On linux run `./bin/build-linux.sh`
    - On linux run `./bin/build-mac.sh`

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ SOFTWARE.
 2. Clone the repository
 3. Rename the folder containing the repository to "code"
 4. At the same level as the "4ed" folder, clone the "4coder-non-source" repository
-5. A. On windows setup the visual studio command line magic sauce so that "cl" works
-   B. On linux setup g++
-   C. On mac setup clang
+5. 
+   - On windows setup the visual studio command line magic sauce so that "cl" works
+   - On linux setup g++
+   - On mac setup clang
 6. Navigate to the "4ed/code" folder.
-7. A. On windows run "bin\build.bat"
-   B. On linux run "bin\build-linux.sh"
-   C. On linux run "bin\build-mac.sh"
+7. 
+   - On windows run "bin\build.bat"
+   - On linux run "bin\build-linux.sh"
+   - On linux run "bin\build-mac.sh"
 
 
 # Notes on Major Issues

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ SOFTWARE.
    - On mac setup clang
 6. Navigate to the "4ed/code" folder.
 7. 
-   - On windows run "bin\build.bat"
-   - On linux run "bin\build-linux.sh"
-   - On linux run "bin\build-mac.sh"
+   - On windows run `bin\build.bat`
+   - On linux run `./bin/build-linux.sh`
+   - On linux run `./bin/build-mac.sh`
 
 
 # Notes on Major Issues

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ root_dir
 7. Run build script.
    - On windows run `bin\build.bat`
    - On linux run `./bin/build-linux.sh`
-   - On linux run `./bin/build-mac.sh`
+   - On mac run `./bin/build-mac.sh`
 
 
 # Notes on Major Issues

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ SOFTWARE.
 
 1. Create an empty folder for the source.
 2. Clone this repository there to a folder named "code".
-   - `git clone -o code <url>`
+   - `git clone <url> code`
 3. At the same level as the "code" folder, clone the "4coder-non-source" repository.
 
 Result should be like this:

--- a/bin/4ed_build.cpp
+++ b/bin/4ed_build.cpp
@@ -318,6 +318,9 @@ build(Arena *arena, u32 flags, u32 arch, char *code_path, char **code_files, cha
 # error gcc options not set for this platform
 #endif
 
+char *native_includes[] = { "freetype2", 0 };
+char *native_include_dir = "/usr/include";
+
 internal void
 build(Arena *arena, u32 flags, u32 arch, char *code_path, char **code_files, char *out_path, char *out_file, char **defines, char **exports, char **inc_folders){
     Build_Line line;
@@ -343,6 +346,16 @@ build(Arena *arena, u32 flags, u32 arch, char *code_path, char **code_files, cha
     if (inc_folders != 0){
         for (u32 i = 0; inc_folders[i] != 0; ++i){
             char *str = fm_str(arena, code_path, "/", inc_folders[i]);
+            fm_add_to_line(line, "-I%s", str);
+        }
+    }
+    
+    if (native_includes != 0){
+        for (u32 i = 0; native_includes[i] != 0; ++i){
+            char *str = fm_str(arena,
+                               native_include_dir,
+                               "/",
+                               native_includes[i]);
             fm_add_to_line(line, "-I%s", str);
         }
     }

--- a/bin/4ed_build.cpp
+++ b/bin/4ed_build.cpp
@@ -582,6 +582,12 @@ build_main(Arena *arena, char *cdir, b32 update_local_theme, u32 flags, u32 arch
         fm_clear_folder(themes_folder);
         fm_make_folder_if_missing(arena, themes_folder);
         fm_copy_all(source_themes_folder, themes_folder);
+
+        char *fonts_folder = fm_str(arena, "../build/fonts");
+        char *source_fonts_folder = fm_str(arena, "../4coder-non-source/dist_files/fonts");
+        fm_clear_folder(fonts_folder);
+        fm_make_folder_if_missing(arena, fonts_folder);
+        fm_copy_all(source_fonts_folder, fonts_folder);
     }
     
     fflush(stdout);


### PR DESCRIPTION
README fixes:
  - better instruction for repo cloning
  - separated clone and build instructions
  - fixed typos
Build system fixes:
  - now build script uses native version of freetype on linux
  - copies required fonts from 4coder-non-source directory